### PR TITLE
Fixed subtle threading issue in ReceivedCommandSignal

### DIFF
--- a/extras/CSharp/CommandMessenger/Properties/AssemblyInfo.cs
+++ b/extras/CSharp/CommandMessenger/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.7.0.0")]
-[assembly: AssemblyFileVersion("3.7.0.0")]
+[assembly: AssemblyVersion("3.7.1.0")]
+[assembly: AssemblyFileVersion("3.7.1.0")]

--- a/extras/CSharp/CommandMessenger/Queue/ReceiveCommandQueue.cs
+++ b/extras/CSharp/CommandMessenger/Queue/ReceiveCommandQueue.cs
@@ -65,9 +65,14 @@ namespace CommandMessenger.Queue
             return hasMoreWork;
         }
 
-        public ReceivedCommand WaitForCmd(int timeOut, int cmdId, SendQueue sendQueueState)
+        public void PrepareForCmd(int cmdId, SendQueue sendQueueState)
         {
-            return _receivedCommandSignal.WaitForCmd(timeOut, cmdId, sendQueueState);
+            _receivedCommandSignal.PrepareForWait(cmdId, sendQueueState);
+        }
+
+        public ReceivedCommand WaitForCmd(int timeOut)
+        {
+            return _receivedCommandSignal.WaitForCmd(timeOut);
         }
 
         /// <summary> Queue the received command. </summary>

--- a/extras/CSharp/CommandMessenger/ReceivedCommandSignal.cs
+++ b/extras/CSharp/CommandMessenger/ReceivedCommandSignal.cs
@@ -32,13 +32,11 @@ namespace CommandMessenger
         private readonly EventWaiter _waiter = new EventWaiter();
 
         /// <summary>
-        /// Wait function. 
+        /// Prepares for the WaitForCmd to be used.
         /// </summary>
-        /// <param name="timeOut">time-out in ms</param>
         /// <param name="cmdId"></param>
         /// <param name="sendQueueState"></param>
-        /// <returns></returns>
-        public ReceivedCommand WaitForCmd(int timeOut, int cmdId, SendQueue sendQueueState)
+        public void PrepareForWait(int cmdId, SendQueue sendQueueState)
         {
             lock (_lock)
             {
@@ -46,15 +44,17 @@ namespace CommandMessenger
                 _cmdIdToMatch = cmdId;
                 _sendQueueState = sendQueueState;
             }
-
-            if (_waiter.WaitOne(timeOut) == EventWaiter.WaitState.TimeOut)
-            {
-                return null;
-            }
-
-            return _receivedCommand;
         }
 
+        /// <summary>
+        /// Wait function. PrepareForWait must be called before to prepare!
+        /// </summary>
+        /// <param name="timeOut">time-out in ms</param>
+        /// <returns></returns>
+        public ReceivedCommand WaitForCmd(int timeOut)
+        {
+            return _waiter.WaitOne(timeOut) == EventWaiter.WaitState.TimeOut ? null : _receivedCommand;
+        }
 
         /// <summary>
         /// Process command. See if it needs to be send to the main thread (false) or be used in queue (true)


### PR DESCRIPTION
Fixed subtle threading issue where ReceivedCommandSignal was setup to wait for a reply AFTER the reply had already been received from the transport layer.  This would result in the response being stomped on when  _receivedCommand was set to null.  Now WaitForCmd is configured beforehand by the PrepareForWait command and then called.  Saw this error every ~10K calls when the response from the Arduino was very fast.  Has only been tested on a Arduino Mega 2560 R3.