### PR TITLE
Invalid ref to dependent library - Adafruit-MAX31885

### DIFF
--- a/library.json
+++ b/library.json
@@ -25,7 +25,7 @@
       "frameworks": "arduino"
     },
     {
-      "name": "Adafruit-MAX31885",
+      "name": "Adafruit-MAX31855",
       "frameworks": "arduino"
     }
   ],


### PR DESCRIPTION
The dependencies of this library has an incorrect entry named as "Adafruit-MAX31885" which do not exist.
The dependency should be 'Adafruit-MAX31855" (the last 2 digits should be 55 instead of 85) which is fixed in this fork.