### PR TITLE
remove callback list and attach(id, callback)

### DIFF
--- a/CmdMessenger.cpp
+++ b/CmdMessenger.cpp
@@ -76,8 +76,6 @@ void CmdMessenger::init(Stream &ccomms, const char fld_separator, const char cmd
 	reset();
 
 	default_callback = NULL;
-	for (int i = 0; i < MAXCALLBACKS; i++)
-		callbackList[i] = NULL;
 
 	pauseProcessing = false;
 }
@@ -107,15 +105,6 @@ void CmdMessenger::printLfCr(bool addNewLine)
 void CmdMessenger::attach(messengerCallbackFunction newFunction)
 {
 	default_callback = newFunction;
-}
-
-/**
- * Attaches a function to a command ID
- */
-void CmdMessenger::attach(byte msgId, messengerCallbackFunction newFunction)
-{
-	if (msgId >= 0 && msgId < MAXCALLBACKS)
-		callbackList[msgId] = newFunction;
 }
 
 // **** Command processing ****
@@ -178,11 +167,8 @@ uint8_t CmdMessenger::processLine(char serialChar)
 void CmdMessenger::handleMessage()
 {
 	lastCommandId = readInt16Arg();
-	// if command attached, we will call it
-	if (lastCommandId >= 0 && lastCommandId < MAXCALLBACKS && ArgOk && callbackList[lastCommandId] != NULL)
-		(*callbackList[lastCommandId])();
-	else // If command not attached, call default callback (if attached)
-		if (default_callback != NULL) (*default_callback)();
+	if (default_callback != NULL)
+	 	(*default_callback)();
 }
 
 /**

--- a/CmdMessenger.h
+++ b/CmdMessenger.h
@@ -27,9 +27,9 @@
 
 #include <inttypes.h>
 #if ARDUINO >= 100
-#include <Arduino.h> 
+#include <Arduino.h>
 #else
-#include <WProgram.h> 
+#include <WProgram.h>
 #endif
 
 //#include "Stream.h"
@@ -40,7 +40,6 @@ extern "C"
 	typedef void(*messengerCallbackFunction) (void);
 }
 
-#define MAXCALLBACKS        50   // The maximum number of commands   (default: 50)
 #define MESSENGERBUFFERSIZE 64   // The length of the commandbuffer  (default: 64)
 #define MAXSTREAMBUFFERSIZE 512  // The length of the streambuffer   (default: 64)
 #define DEFAULT_TIMEOUT     5000 // Time out on unanswered messages. (default: 5s)
@@ -84,8 +83,7 @@ private:
 	char field_separator;				// Character indicating end of argument (default: ',')
 	char escape_character;		    // Character indicating escaping of special chars
 
-	messengerCallbackFunction default_callback;            // default callback function  
-	messengerCallbackFunction callbackList[MAXCALLBACKS];  // list of attached callback functions 
+	messengerCallbackFunction default_callback;            // default callback function
 
 
 	// **** Initialize ****
@@ -170,7 +168,6 @@ public:
 
 	void printLfCr(bool addNewLine = true);
 	void attach(messengerCallbackFunction newFunction);
-	void attach(byte msgId, messengerCallbackFunction newFunction);
 
 	// **** Command processing ****
 


### PR DESCRIPTION
taking too much memory space...
just do it in the default handler with a big switch-case would be more
memory efficient (saved a bit code space, too)...