### PR TITLE
Unity Compatibility

### DIFF
--- a/extras/CSharp/ArduinoController/ArduinoController.cs
+++ b/extras/CSharp/ArduinoController/ArduinoController.cs
@@ -53,9 +53,6 @@ namespace ArduinoController
             // Set if it is communicating with a 16- or 32-bit Arduino board
             _cmdMessenger = new CmdMessenger(_serialTransport, BoardType.Bit16);
 
-            // Tell CmdMessenger to "Invoke" commands on the thread running the WinForms UI
-            _cmdMessenger.ControlToInvokeOn = _controllerForm;
-
             // Attach the callbacks to the Command Messenger
             AttachCommandCallBacks();
 

--- a/extras/CSharp/CommandMessenger.Transport.Serial/CommandMessenger.Transport.Serial.csproj
+++ b/extras/CSharp/CommandMessenger.Transport.Serial/CommandMessenger.Transport.Serial.csproj
@@ -54,7 +54,6 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
   </ItemGroup>

--- a/extras/CSharp/CommandMessenger.Transport.Serial/SerialConnectionManager.cs
+++ b/extras/CSharp/CommandMessenger.Transport.Serial/SerialConnectionManager.cs
@@ -331,7 +331,7 @@ namespace CommandMessenger.Transport.Serial
 
             //TODO: 4s - practical delay for Leonardo board, probably for other boards will be different. Need to investigate more on this.
             const int waitTime = 4000;
-            Log(1, "New port(s) " + string.Join(",", newPorts) + " detected, wait for " + (waitTime / 1000.0) + "s before attempt to connect.");
+            Log(1, "New port(s) " + string.Join(",", newPorts.ToArray()) + " detected, wait for " + (waitTime / 1000.0) + "s before attempt to connect.");
 
             // Wait a bit before new port will be available then try to connect
             Thread.Sleep(waitTime);

--- a/extras/CSharp/CommandMessenger/CmdMessenger.cs
+++ b/extras/CSharp/CommandMessenger/CmdMessenger.cs
@@ -19,8 +19,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Threading;
-using System.Windows.Forms;
 using CommandMessenger.Queue;
 using CommandMessenger.Transport;
 
@@ -84,11 +82,6 @@ namespace CommandMessenger
             get { return _communicationManager.PrintLfCr; }
             set { _communicationManager.PrintLfCr = value; }
         }
-
-        /// <summary>
-        /// The control to invoke the callback on
-        /// </summary>
-        public Control ControlToInvokeOn { get; set; }
 
         /// <summary> Constructor. </summary>
         /// <param name="transport"> The transport layer. </param>
@@ -159,8 +152,6 @@ namespace CommandMessenger
         private void Init(ITransport transport, BoardType boardType, char fieldSeparator, char commandSeparator,
                           char escapeCharacter, int sendBufferMaxLength)
         {           
-            ControlToInvokeOn = null;
-
             //Logger.Open(@"sendCommands.txt");
             Logger.DirectFlush = true;
 
@@ -187,14 +178,6 @@ namespace CommandMessenger
         {
             Dispose(true);
             GC.SuppressFinalize(this);
-        }
-
-        /// <summary> Sets a control to invoke on. </summary>
-        /// <param name="controlToInvokeOn"> The control to invoke on. </param>
-        [Obsolete("Use ControlToInvokeOn property instead.")]
-        public void SetControlToInvokeOn(Control controlToInvokeOn)
-        {
-            ControlToInvokeOn = controlToInvokeOn;
         }
 
         /// <summary>  Stop listening and end serial port connection. </summary>
@@ -397,15 +380,8 @@ namespace CommandMessenger
         /// <param name="newLineArgs"></param>
         private void InvokeNewLineEvent(EventHandler<CommandEventArgs> newLineHandler, CommandEventArgs newLineArgs)
         {
-            if (newLineHandler == null || (ControlToInvokeOn != null && ControlToInvokeOn.IsDisposed)) return;
-
-            if (ControlToInvokeOn != null)
-            {
-                //Asynchronously call on UI thread
-                ControlToInvokeOn.BeginInvoke((MethodInvoker)(() => newLineHandler(this, newLineArgs)));
-            }
-            else
-            {
+            if (newLineHandler != null)
+            { 
                 //Directly call
                 newLineHandler(this, newLineArgs);
             }
@@ -416,14 +392,7 @@ namespace CommandMessenger
         /// <param name="command">                   The command. </param>
         private void InvokeCallBack(MessengerCallbackFunction messengerCallbackFunction, ReceivedCommand command)
         {
-            if (messengerCallbackFunction == null || (ControlToInvokeOn != null && ControlToInvokeOn.IsDisposed)) return;
-
-            if (ControlToInvokeOn != null)
-            {
-                //Asynchronously call on UI thread
-                ControlToInvokeOn.BeginInvoke(new MessengerCallbackFunction(messengerCallbackFunction), (object)command);
-            }
-            else
+            if (messengerCallbackFunction != null)
             {
                 //Directly call
                 messengerCallbackFunction(command);
@@ -434,8 +403,6 @@ namespace CommandMessenger
         {
             if (disposing)
             {
-                ControlToInvokeOn = null;
-
                 _communicationManager.Dispose();
                 _sendCommandQueue.Dispose();
                 _receiveCommandQueue.Dispose();

--- a/extras/CSharp/CommandMessenger/CommandMessenger.csproj
+++ b/extras/CSharp/CommandMessenger/CommandMessenger.csproj
@@ -51,10 +51,8 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Management" />
-    <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
   </ItemGroup>
@@ -86,6 +84,7 @@
     <Compile Include="Escaped.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SendCommand.cs" />
+    <Compile Include="SpinWait.cs" />
     <Compile Include="StructSerializer.cs" />
     <Compile Include="Transport\ITransport.cs" />
     <Compile Include="StringUtils.cs" />

--- a/extras/CSharp/CommandMessenger/ConnectionManager.cs
+++ b/extras/CSharp/CommandMessenger/ConnectionManager.cs
@@ -19,7 +19,6 @@
 
 using System;
 using System.Threading;
-using System.Windows.Forms;
 
 namespace CommandMessenger
 {
@@ -196,19 +195,8 @@ namespace CommandMessenger
         private void InvokeEvent<TEventHandlerArguments>(EventHandler<TEventHandlerArguments> eventHandler,
             TEventHandlerArguments eventHandlerArguments) where TEventHandlerArguments : EventArgs
         {
-            var ctrlToInvoke = _cmdMessenger.ControlToInvokeOn;
-
-            if (eventHandler == null || (ctrlToInvoke != null && ctrlToInvoke.IsDisposed)) return;
-            if (ctrlToInvoke != null )
-            {
-                try { ctrlToInvoke.BeginInvoke((MethodInvoker)(() => eventHandler(this, eventHandlerArguments))); } catch { }
-            }
-            else
-            {   
-				//Invoke here             
-                try { eventHandler.BeginInvoke(this, eventHandlerArguments, null, null); } catch { }
-                
-            }
+    		//Invoke here             
+            try { eventHandler.BeginInvoke(this, eventHandlerArguments, null, null); } catch { }
         }
 
         private bool DoWork()

--- a/extras/CSharp/CommandMessenger/Queue/SendCommandQueue.cs
+++ b/extras/CSharp/CommandMessenger/Queue/SendCommandQueue.cs
@@ -160,7 +160,7 @@ namespace CommandMessenger.Queue
         {
             while (Queue.Count > MaxQueueLength)
             {
-                Thread.Yield();
+                Thread.Sleep(0);
             }
 
             lock (Queue)

--- a/extras/CSharp/CommandMessenger/SpinWait.cs
+++ b/extras/CSharp/CommandMessenger/SpinWait.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace CommandMessenger
+{
+    class SpinWait
+    {
+        public static void SpinUntil(Func<bool> func)
+        {
+            while (!func.Invoke()) ;
+        }
+    }
+}

--- a/extras/CSharp/DataLogging/DataLogging.cs
+++ b/extras/CSharp/DataLogging/DataLogging.cs
@@ -53,9 +53,6 @@ namespace DataLogging
             // Set if it is communicating with a 16- or 32-bit Arduino board
             _cmdMessenger = new CmdMessenger(_serialTransport, BoardType.Bit16);
 
-            // Tell CmdMessenger to "Invoke" commands on the thread running the WinForms UI
-            _cmdMessenger.ControlToInvokeOn = chartForm;
-
             // Set Received command strategy that removes commands that are older than 1 sec
             _cmdMessenger.AddReceiveCommandStrategy(new StaleGeneralStrategy(1000));
 
@@ -142,9 +139,5 @@ namespace DataLogging
         {
             Console.WriteLine(@"Sent > " + e.Command.CommandString());
         }
-
-
-
-
     }
 }

--- a/extras/CSharp/TemperatureControl/TemperatureControl.cs
+++ b/extras/CSharp/TemperatureControl/TemperatureControl.cs
@@ -20,6 +20,7 @@ using CommandMessenger.Transport;
 using CommandMessenger.Transport.Bluetooth;
 using CommandMessenger.Transport.Serial;
 using System.Threading;
+using System.Windows.Forms;
 
 namespace DataLogging
 {
@@ -116,9 +117,6 @@ namespace DataLogging
                 PrintLfCr = false            // Do not print newLine at end of command, to reduce data being sent
             };
 
-            // Tell CmdMessenger to "Invoke" commands on the thread running the WinForms UI
-            _cmdMessenger.ControlToInvokeOn = chartForm;
-
             // Set command strategy to continuously to remove all commands on the receive queue that 
             // are older than 1 sec. This makes sure that if data logging comes in faster that it can 
             // be plotted, the graph will not start lagging
@@ -205,19 +203,28 @@ namespace DataLogging
         // In a WinForm application, console output gets routed to the output panel of your IDE
         void OnUnknownCommand(ReceivedCommand arguments)
         {
-            _chartForm.LogMessage(@"Command without attached callback received");
+            if (_chartForm.InvokeRequired)
+                _chartForm.Invoke(new MethodInvoker(() => { _chartForm.LogMessage(@"Command without attached callback received"); }));
+            else
+                _chartForm.LogMessage(@"Command without attached callback received");
         }
 
         // Callback function that prints that the Arduino has acknowledged
         void OnAcknowledge(ReceivedCommand arguments)
         {
-            _chartForm.LogMessage(@"Arduino acknowledged");
+            if (_chartForm.InvokeRequired)
+                _chartForm.Invoke(new MethodInvoker(() => { _chartForm.LogMessage(@"Arduino acknowledged"); }));
+            else
+                _chartForm.LogMessage(@"Arduino acknowledged");
         }
 
         // Callback function that prints that the Arduino has experienced an error
         void OnError(ReceivedCommand arguments)
         {
-            _chartForm.LogMessage(@"Arduino has experienced an error");
+            if (_chartForm.InvokeRequired)
+                _chartForm.Invoke(new MethodInvoker(() => { _chartForm.LogMessage(@"Arduino has experienced an error"); }));
+            else
+                _chartForm.LogMessage(@"Arduino has experienced an error");
         }
 
         // Callback function that plots a data point for the current temperature, the goal temperature,
@@ -242,15 +249,22 @@ namespace DataLogging
         // Log received line to console
         private void NewLineReceived(object sender, CommandEventArgs e)
         {
-            _chartForm.LogMessage(@"Received > " + e.Command.CommandString());
-          //  Console.WriteLine(@"Received > " + e.Command.CommandString());
+            if (_chartForm.InvokeRequired)
+                _chartForm.Invoke(new MethodInvoker(() => { _chartForm.LogMessage(@"Received > " + e.Command.CommandString()); }));
+            else
+                _chartForm.LogMessage(@"Received > " + e.Command.CommandString());
+            
+            // Console.WriteLine(@"Received > " + e.Command.CommandString());
         }
 
         // Log sent line to console
         private void NewLineSent(object sender, CommandEventArgs e)
         {
-            _chartForm.LogMessage(@"Sent > " + e.Command.CommandString());
-           // Console.WriteLine(@"Sent > " + e.Command.CommandString());
+            if (_chartForm.InvokeRequired)
+                _chartForm.Invoke(new MethodInvoker(() => { _chartForm.LogMessage(@"Sent > " + e.Command.CommandString()); }));
+            else
+                _chartForm.LogMessage(@"Sent > " + e.Command.CommandString());
+            // Console.WriteLine(@"Sent > " + e.Command.CommandString());
         }
 
         // Log connection manager progress to status bar


### PR DESCRIPTION
1. remove `Microsoft.CSharp` reference
2. remove `System.Windows.Forms` reference
3. backport `SpinWait` class
4. use `Thread.Sleep(0)` instead of `Thread.Yield()`