### PR TITLE
Reduce mem footprint

### DIFF
--- a/CmdMessenger.cpp
+++ b/CmdMessenger.cpp
@@ -76,8 +76,10 @@ void CmdMessenger::init(Stream &ccomms, const char fld_separator, const char cmd
 	reset();
 
 	default_callback = NULL;
+#if CMDMESSENGER_MAXCALLBACKS != 0
 	for (int i = 0; i < CMDMESSENGER_MAXCALLBACKS; i++)
 		callbackList[i] = NULL;
+#endif
 
 	pauseProcessing = false;
 }
@@ -114,8 +116,10 @@ void CmdMessenger::attach(messengerCallbackFunction newFunction)
  */
 void CmdMessenger::attach(byte msgId, messengerCallbackFunction newFunction)
 {
+#if CMDMESSENGER_MAXCALLBACKS != 0
 	if (msgId >= 0 && msgId < CMDMESSENGER_MAXCALLBACKS)
 		callbackList[msgId] = newFunction;
+#endif
 }
 
 // **** Command processing ****
@@ -179,9 +183,11 @@ void CmdMessenger::handleMessage()
 {
 	lastCommandId = readInt16Arg();
 	// if command attached, we will call it
+#if CMDMESSENGER_MAXCALLBACKS != 0
 	if (lastCommandId >= 0 && lastCommandId < CMDMESSENGER_MAXCALLBACKS && ArgOk && callbackList[lastCommandId] != NULL)
 		(*callbackList[lastCommandId])();
 	else // If command not attached, call default callback (if attached)
+#endif
 		if (default_callback != NULL) (*default_callback)();
 }
 

--- a/CmdMessenger.cpp
+++ b/CmdMessenger.cpp
@@ -71,12 +71,12 @@ void CmdMessenger::init(Stream &ccomms, const char fld_separator, const char cmd
 	field_separator = fld_separator;
 	command_separator = cmd_separator;
 	escape_character = esc_character;
-	bufferLength = MESSENGERBUFFERSIZE;
-	bufferLastIndex = MESSENGERBUFFERSIZE - 1;
+	bufferLength = CMDMESSENGER_MESSENGERBUFFERSIZE;
+	bufferLastIndex = CMDMESSENGER_MESSENGERBUFFERSIZE - 1;
 	reset();
 
 	default_callback = NULL;
-	for (int i = 0; i < MAXCALLBACKS; i++)
+	for (int i = 0; i < CMDMESSENGER_MAXCALLBACKS; i++)
 		callbackList[i] = NULL;
 
 	pauseProcessing = false;
@@ -114,7 +114,7 @@ void CmdMessenger::attach(messengerCallbackFunction newFunction)
  */
 void CmdMessenger::attach(byte msgId, messengerCallbackFunction newFunction)
 {
-	if (msgId >= 0 && msgId < MAXCALLBACKS)
+	if (msgId >= 0 && msgId < CMDMESSENGER_MAXCALLBACKS)
 		callbackList[msgId] = newFunction;
 }
 
@@ -130,7 +130,7 @@ void CmdMessenger::feedinSerialData()
 		// The Stream class has a readBytes() function that reads many bytes at once. On Teensy 2.0 and 3.0, readBytes() is optimized. 
 		// Benchmarks about the incredible difference it makes: http://www.pjrc.com/teensy/benchmark_usb_serial_receive.html
 
-		size_t bytesAvailable = min(comms->available(), MAXSTREAMBUFFERSIZE);
+		size_t bytesAvailable = min(comms->available(), CMDMESSENGER_MAXSTREAMBUFFERSIZE);
 		comms->readBytes(streamBuffer, bytesAvailable);
 
 		// Process the bytes in the stream buffer, and handles dispatches callbacks, if commands are received
@@ -179,7 +179,7 @@ void CmdMessenger::handleMessage()
 {
 	lastCommandId = readInt16Arg();
 	// if command attached, we will call it
-	if (lastCommandId >= 0 && lastCommandId < MAXCALLBACKS && ArgOk && callbackList[lastCommandId] != NULL)
+	if (lastCommandId >= 0 && lastCommandId < CMDMESSENGER_MAXCALLBACKS && ArgOk && callbackList[lastCommandId] != NULL)
 		(*callbackList[lastCommandId])();
 	else // If command not attached, call default callback (if attached)
 		if (default_callback != NULL) (*default_callback)();
@@ -353,7 +353,7 @@ bool CmdMessenger::sendCmd(byte cmdId, bool reqAc, byte ackCmdId)
 {
 	if (!startCommand) {
 		sendCmdStart(cmdId);
-		return sendCmdEnd(reqAc, ackCmdId, DEFAULT_TIMEOUT);
+		return sendCmdEnd(reqAc, ackCmdId, CMDMESSENGER_DEFAULT_TIMEOUT);
 	}
 	return false;
 }
@@ -365,7 +365,7 @@ bool CmdMessenger::sendCmd(byte cmdId)
 {
 	if (!startCommand) {
 		sendCmdStart(cmdId);
-		return sendCmdEnd(false, 1, DEFAULT_TIMEOUT);
+		return sendCmdEnd(false, 1, CMDMESSENGER_DEFAULT_TIMEOUT);
 	}
 	return false;
 }

--- a/CmdMessenger.h
+++ b/CmdMessenger.h
@@ -40,10 +40,18 @@ extern "C"
 	typedef void(*messengerCallbackFunction) (void);
 }
 
+#ifndef CMDMESSENGER_MAXCALLBACKS
 #define CMDMESSENGER_MAXCALLBACKS        50   // The maximum number of commands   (default: 50)
+#endif
+#ifndef CMDMESSENGER_MESSENGERBUFFERSIZE
 #define CMDMESSENGER_MESSENGERBUFFERSIZE 64   // The length of the commandbuffer  (default: 64)
+#endif
+#ifndef CMDMESSENGER_MAXSTREAMBUFFERSIZE
 #define CMDMESSENGER_MAXSTREAMBUFFERSIZE 512  // The length of the streambuffer   (default: 64)
+#endif
+#ifndef CMDMESSENGER_DEFAULT_TIMEOUT
 #define CMDMESSENGER_DEFAULT_TIMEOUT     5000 // Time out on unanswered messages. (default: 5s)
+#endif
 
 // Message States
 enum

--- a/CmdMessenger.h
+++ b/CmdMessenger.h
@@ -40,10 +40,10 @@ extern "C"
 	typedef void(*messengerCallbackFunction) (void);
 }
 
-#define MAXCALLBACKS        50   // The maximum number of commands   (default: 50)
-#define MESSENGERBUFFERSIZE 64   // The length of the commandbuffer  (default: 64)
-#define MAXSTREAMBUFFERSIZE 512  // The length of the streambuffer   (default: 64)
-#define DEFAULT_TIMEOUT     5000 // Time out on unanswered messages. (default: 5s)
+#define CMDMESSENGER_MAXCALLBACKS        50   // The maximum number of commands   (default: 50)
+#define CMDMESSENGER_MESSENGERBUFFERSIZE 64   // The length of the commandbuffer  (default: 64)
+#define CMDMESSENGER_MAXSTREAMBUFFERSIZE 512  // The length of the streambuffer   (default: 64)
+#define CMDMESSENGER_DEFAULT_TIMEOUT     5000 // Time out on unanswered messages. (default: 5s)
 
 // Message States
 enum
@@ -64,14 +64,14 @@ private:
 	bool    startCommand;            // Indicates if sending of a command is underway
 	uint8_t lastCommandId;		    // ID of last received command 
 	uint8_t bufferIndex;              // Index where to write data in buffer
-	uint8_t bufferLength;             // Is set to MESSENGERBUFFERSIZE
+	uint8_t bufferLength;             // Is set to CMDMESSENGER_MESSENGERBUFFERSIZE
 	uint8_t bufferLastIndex;          // The last index of the buffer
 	char ArglastChar;                 // Bookkeeping of argument escape char 
 	char CmdlastChar;                 // Bookkeeping of command escape char 
 	bool pauseProcessing;             // pauses processing of new commands, during sending
 	bool print_newlines;              // Indicates if \r\n should be added after send command
-	char commandBuffer[MESSENGERBUFFERSIZE]; // Buffer that holds the data
-	char streamBuffer[MAXSTREAMBUFFERSIZE]; // Buffer that holds the data
+	char commandBuffer[CMDMESSENGER_MESSENGERBUFFERSIZE]; // Buffer that holds the data
+	char streamBuffer[CMDMESSENGER_MAXSTREAMBUFFERSIZE]; // Buffer that holds the data
 	uint8_t messageState;             // Current state of message processing
 	bool dumped;                      // Indicates if last argument has been externally read 
 	bool ArgOk;						// Indicated if last fetched argument could be read
@@ -85,7 +85,7 @@ private:
 	char escape_character;		    // Character indicating escaping of special chars
 
 	messengerCallbackFunction default_callback;            // default callback function  
-	messengerCallbackFunction callbackList[MAXCALLBACKS];  // list of attached callback functions 
+	messengerCallbackFunction callbackList[CMDMESSENGER_MAXCALLBACKS];  // list of attached callback functions
 
 
 	// **** Initialize ****
@@ -97,7 +97,7 @@ private:
 
 	inline uint8_t processLine(char serialChar) __attribute__((always_inline));
 	inline void handleMessage() __attribute__((always_inline));
-	inline bool blockedTillReply(unsigned int timeout = DEFAULT_TIMEOUT, byte ackCmdId = 1) __attribute__((always_inline));
+	inline bool blockedTillReply(unsigned int timeout = CMDMESSENGER_DEFAULT_TIMEOUT, byte ackCmdId = 1) __attribute__((always_inline));
 	inline bool checkForAck(byte AckCommand) __attribute__((always_inline));
 
 	// **** Command sending ****
@@ -188,7 +188,7 @@ public:
 	 */
 	template < class T >
 	bool sendCmd(byte cmdId, T arg, bool reqAc = false, byte ackCmdId = 1,
-		unsigned int timeout = DEFAULT_TIMEOUT)
+		unsigned int timeout = CMDMESSENGER_DEFAULT_TIMEOUT)
 	{
 		if (!startCommand) {
 			sendCmdStart(cmdId);
@@ -204,7 +204,7 @@ public:
 	 */
 	template < class T >
 	bool sendBinCmd(byte cmdId, T arg, bool reqAc = false, byte ackCmdId = 1,
-		unsigned int timeout = DEFAULT_TIMEOUT)
+		unsigned int timeout = CMDMESSENGER_DEFAULT_TIMEOUT)
 	{
 		if (!startCommand) {
 			sendCmdStart(cmdId);
@@ -221,7 +221,7 @@ public:
 	void sendCmdStart(byte cmdId);
 	void sendCmdEscArg(char *arg);
 	void sendCmdfArg(char *fmt, ...);
-	bool sendCmdEnd(bool reqAc = false, byte ackCmdId = 1, unsigned int timeout = DEFAULT_TIMEOUT);
+	bool sendCmdEnd(bool reqAc = false, byte ackCmdId = 1, unsigned int timeout = CMDMESSENGER_DEFAULT_TIMEOUT);
 
 	/**
 	 * Send a single argument as string

--- a/CmdMessenger.h
+++ b/CmdMessenger.h
@@ -93,7 +93,9 @@ private:
 	char escape_character;		    // Character indicating escaping of special chars
 
 	messengerCallbackFunction default_callback;            // default callback function  
+#if CMDMESSENGER_MAXCALLBACKS != 0
 	messengerCallbackFunction callbackList[CMDMESSENGER_MAXCALLBACKS];  // list of attached callback functions
+#endif
 
 
 	// **** Initialize ****


### PR DESCRIPTION
declare callback list only when MAXCALLBACKS != 0
reduce memory and binary footprint.

the code actually run faster with a giant switch-case as the default handler...