### PR TITLE
make sendCmdfArg() receive `const char * const` as fmt

### DIFF
--- a/CmdMessenger.cpp
+++ b/CmdMessenger.cpp
@@ -299,7 +299,7 @@ void CmdMessenger::sendCmdEscArg(char* arg)
  * Send formatted argument.
  *  Note that floating points are not supported and resulting string is limited to 128 chars
  */
-void CmdMessenger::sendCmdfArg(char *fmt, ...)
+void CmdMessenger::sendCmdfArg(const char * const fmt, ...)
 {
 	const int maxMessageSize = 128;
 	if (startCommand) {

--- a/CmdMessenger.h
+++ b/CmdMessenger.h
@@ -220,7 +220,7 @@ public:
 
 	void sendCmdStart(byte cmdId);
 	void sendCmdEscArg(char *arg);
-	void sendCmdfArg(char *fmt, ...);
+	void sendCmdfArg(const char * const fmt, ...);
 	bool sendCmdEnd(bool reqAc = false, byte ackCmdId = 1, unsigned int timeout = DEFAULT_TIMEOUT);
 
 	/**


### PR DESCRIPTION
reduce compiler warning...