### PR TITLE
Added explicit type cast to fix compile error 

### DIFF
--- a/CmdMessenger.cpp
+++ b/CmdMessenger.cpp
@@ -489,7 +489,7 @@ char* CmdMessenger::readStringArg()
 		return current;
 	}
 	ArgOk = false;
-	return '\0';
+	return (char*)'\0';
 }
 
 /**


### PR DESCRIPTION
The added explicit type cast fixes the compile errors described in issue #49.